### PR TITLE
Fix quiz cld

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -125,7 +125,40 @@ jobs:
         echo "create_tag=$create_tag" >> "$GITHUB_OUTPUT"
         echo "display_version=$display_version" >> "$GITHUB_OUTPUT"
 
+    - name: Log in to Docker Hub (main only)
+      if: github.ref == 'refs/heads/main'
+      uses: docker/login-action@v4
+      with:
+        username: ${{ vars.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Try to promote PR-built image (main only)
+      id: promote
+      if: github.ref == 'refs/heads/main'
+      run: |
+        set -euo pipefail
+        PARENTS=$(git log --pretty=format:"%P" -1)
+        SECOND_PARENT=$(echo "$PARENTS" | awk '{print $2}')
+        if [ -n "$SECOND_PARENT" ]; then
+          PR_HEAD_SHORT="${SECOND_PARENT:0:7}"
+        else
+          PR_HEAD_SHORT="${GITHUB_SHA::7}"
+        fi
+        PR_IMAGE="${IMAGE_NAME}:commit-${PR_HEAD_SHORT}"
+        echo "Attempting to promote ${PR_IMAGE}..."
+        if docker pull "${PR_IMAGE}" 2>/dev/null; then
+          echo "promoted=true" >> "$GITHUB_OUTPUT"
+          docker tag "${PR_IMAGE}" "${IMAGE_NAME}:${{ steps.meta.outputs.commit_tag }}"
+          docker push "${IMAGE_NAME}:${{ steps.meta.outputs.commit_tag }}"
+          docker save "${IMAGE_NAME}:${{ steps.meta.outputs.commit_tag }}" -o /tmp/image.tar
+          echo "Promotion successful: ${PR_IMAGE} -> ${{ steps.meta.outputs.commit_tag }}"
+        else
+          echo "promoted=false" >> "$GITHUB_OUTPUT"
+          echo "PR-built image not found, falling back to fresh build."
+        fi
+
     - name: Build Docker image (pub-site)
+      if: steps.promote.outputs.promoted != 'true'
       uses: docker/build-push-action@v7
       with:
         context: .
@@ -152,7 +185,7 @@ jobs:
         outputs: type=docker,dest=/tmp/terminal-image.tar
 
     - name: Load pub-site image (main only)
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main' && steps.promote.outputs.promoted != 'true'
       run: |
         set -euo pipefail
         docker load --input /tmp/image.tar
@@ -163,15 +196,8 @@ jobs:
         set -euo pipefail
         docker load --input /tmp/terminal-image.tar
 
-    - name: Log in to Docker Hub (main only)
-      if: github.ref == 'refs/heads/main'
-      uses: docker/login-action@v4
-      with:
-        username: ${{ vars.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
     - name: Push pub-site image (commit tag, main only)
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main' && steps.promote.outputs.promoted != 'true'
       run: |
         set -euo pipefail
         docker push "${IMAGE_NAME}:${{ steps.meta.outputs.commit_tag }}"

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ public/images/iac-sandbox.svg
 public/images/purp-sandbox.jpg
 public/images/solar8bit.jpeg
 .nvmrc
+.pr_changes.md
 
 # Trivy scan outputs
 trivy-*.json

--- a/k8s-1.35-manifests/certificates-production.yaml
+++ b/k8s-1.35-manifests/certificates-production.yaml
@@ -30,6 +30,20 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  name: calc-prod-cert
+  namespace: nginx-gateway
+spec:
+  secretName: calc-prod-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-gateway
+  dnsNames:
+  - calc.dremer10.com
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
   name: grafana-cert
   namespace: nginx-gateway
 spec:

--- a/k8s-1.35-manifests/certificates-staging.yaml
+++ b/k8s-1.35-manifests/certificates-staging.yaml
@@ -30,6 +30,20 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  name: calc-staging-cert
+  namespace: nginx-gateway
+spec:
+  secretName: calc-staging-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-gateway
+  dnsNames:
+  - calc-staging.dremer10.com
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
   name: grafana-staging-cert
   namespace: nginx-gateway
 spec:

--- a/k8s-1.35-manifests/global-gateway.yaml
+++ b/k8s-1.35-manifests/global-gateway.yaml
@@ -182,3 +182,27 @@ spec:
     allowedRoutes:
       namespaces:
         from: All
+  - name: calc-prod
+    hostname: calc.dremer10.com
+    port: 443
+    protocol: HTTPS
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: calc-prod-tls
+        kind: Secret
+    allowedRoutes:
+      namespaces:
+        from: All
+  - name: calc-staging
+    hostname: calc-staging.dremer10.com
+    port: 443
+    protocol: HTTPS
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: calc-staging-tls
+        kind: Secret
+    allowedRoutes:
+      namespaces:
+        from: All

--- a/k8s-1.35-manifests/quiz-staging.yaml
+++ b/k8s-1.35-manifests/quiz-staging.yaml
@@ -28,7 +28,6 @@ spec:
         environment: staging
     spec:
       securityContext:
-        runAsNonRoot: true
         runAsUser: 10001
         runAsGroup: 10001
         fsGroup: 10001
@@ -36,11 +35,31 @@ spec:
         - 995
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: fix-docker-sock
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - chown root:995 /var/run/docker.sock && chmod 660 /var/run/docker.sock
+        securityContext:
+          runAsUser: 0
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - CHOWN
+        volumeMounts:
+        - name: docker-sock
+          mountPath: /var/run/docker.sock
       containers:
       - name: quiz
         image: dremer10/quiz-terminal:${QUIZ_IMAGE_TAG}
         imagePullPolicy: Always
         securityContext:
+          runAsNonRoot: true
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           capabilities:

--- a/k8s-1.35-manifests/quiz-staging.yaml
+++ b/k8s-1.35-manifests/quiz-staging.yaml
@@ -28,38 +28,19 @@ spec:
         environment: staging
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 10001
         runAsGroup: 10001
         fsGroup: 10001
         supplementalGroups:
-        - 995
+        - 988
         seccompProfile:
           type: RuntimeDefault
-      initContainers:
-      - name: fix-docker-sock
-        image: busybox:1.36
-        command:
-        - sh
-        - -c
-        - chown root:995 /var/run/docker.sock && chmod 660 /var/run/docker.sock
-        securityContext:
-          runAsUser: 0
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop:
-            - ALL
-            add:
-            - CHOWN
-        volumeMounts:
-        - name: docker-sock
-          mountPath: /var/run/docker.sock
       containers:
       - name: quiz
         image: dremer10/quiz-terminal:${QUIZ_IMAGE_TAG}
         imagePullPolicy: Always
         securityContext:
-          runAsNonRoot: true
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           capabilities:

--- a/k8s-1.35-manifests/quiz.yaml
+++ b/k8s-1.35-manifests/quiz.yaml
@@ -33,7 +33,7 @@ spec:
         runAsGroup: 10001
         fsGroup: 10001
         supplementalGroups:
-        - 995
+        - 988
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/src/pages/LlmHardwareCalculator.jsx
+++ b/src/pages/LlmHardwareCalculator.jsx
@@ -4,6 +4,11 @@ import { ArrowLeft, ExternalLink, HardDrive, Calculator, Activity } from "lucide
 import PageWrapper from "@/components/PageWrapper";
 import { StickyButtons } from "@/components/StickyButtons";
 
+const calcLiveUrl =
+  typeof window !== "undefined" && window.location.hostname === "info-staging.dremer10.com"
+    ? "https://calc-staging.dremer10.com"
+    : "https://calc.dremer10.com";
+
 const LlmHardwareCalculator = () => {
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: "instant" });
@@ -68,7 +73,7 @@ const LlmHardwareCalculator = () => {
 
                 <div className="flex flex-wrap gap-3">
                   <a
-                    href="https://calc.dremer10.com"
+                    href={calcLiveUrl}
                     target="_blank"
                     rel="noreferrer"
                     className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-sky-500 text-black text-sm font-semibold hover:bg-sky-400 transition-all"

--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -8,6 +8,7 @@ const isInfoStaging =
   typeof window !== "undefined" && window.location.hostname === "info-staging.dremer10.com";
 const iacLiveUrl = isInfoStaging ? "https://iac-sandbox-staging.dremer10.com/" : "https://iac-sandbox.dremer10.com";
 const solarLiveUrl = isInfoStaging ? "https://solar-dev.dremer10.com" : "https://solar.dremer10.com";
+const calcLiveUrl = isInfoStaging ? "https://calc-staging.dremer10.com" : "https://calc.dremer10.com";
 
 export const projects = [
   {
@@ -79,7 +80,7 @@ export const projects = [
     detailPath: "/projects/llm-hardware-calculator",
     ctas: [
       { label: "View detail", to: "/projects/llm-hardware-calculator", type: "internal" },
-      { label: "Check it Out Live", href: "https://calc.dremer10.com", type: "external" },
+      { label: "Check it Out Live", href: calcLiveUrl, type: "external" },
     ],
   },
 ];


### PR DESCRIPTION
Fixes for quiz psuedo-terminal
- docker group `GID` on the host simply changed from `9xx` to `9xx` when `k3s` was upgraded. `GID 9xx` was correct for `1.35.x, 9xx` is what `1.35.x` uses.

Fixed llm-calc routing and cert management for both clusters

Update image promotion flow